### PR TITLE
Added UUID to player_login event

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitPlayerEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitPlayerEvents.java
@@ -368,6 +368,11 @@ public class BukkitPlayerEvents {
 		}
 
 		@Override
+		public String getUniqueId() {
+			return event.getPlayer().getUniqueId().toString();
+		}
+
+		@Override
 		public String getKickMessage() {
 			return event.getKickMessage();
 		}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCPlayerLoginEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCPlayerLoginEvent.java
@@ -6,6 +6,7 @@ package com.laytonsmith.abstraction.events;
  */
 public interface MCPlayerLoginEvent extends MCPlayerEvent{
     public String getName();
+    public String getUniqueId();
     public String getKickMessage();
     public void setKickMessage(String msg);
     public String getResult();

--- a/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
+++ b/src/main/java/com/laytonsmith/core/events/drivers/PlayerEvents.java
@@ -659,8 +659,9 @@ public class PlayerEvents {
 					+ "'result' to KICK_BANNED, KICK_WHITELIST, KICK_OTHER, or KICK_FULL. "
                     + "The default for 'result' is ALLOWED. When setting 'result', you "
                     + "can specify the kick message by modifying 'kickmsg'. "
-                    + "{player: The player's name | kickmsg: The default kick message | "
-                    + "ip: the player's IP address | result: the default response to their logging in}"
+                    + "{player: The player's name | uuid: The player's unique id | "
+					+ "kickmsg: The default kick message | ip: the player's IP address | "
+					+ "result: the default response to their logging in}"
                     + "{kickmsg|result}"
                     + "{player|kickmsg|ip|result}";
 		}
@@ -693,6 +694,7 @@ public class PlayerEvents {
                 Map<String, Construct> map = evaluate_helper(e);
 
                 map.put("player", new CString(event.getName(), Target.UNKNOWN));
+				map.put("uuid", new CString(event.getUniqueId(), Target.UNKNOWN));
                 map.put("ip", new CString(event.getIP(), Target.UNKNOWN));
 				//TODO: The event.getResult needs to be enum'd
                 map.put("result", new CString(event.getResult(), Target.UNKNOWN));


### PR DESCRIPTION
It's not possible to get the player's UUID in this event -- with pinfo(player(), 20) for example. However, it's very useful to have.