### PR TITLE
Add smart string support in notepad++ syntax highlighters.

### DIFF
--- a/src/main/resources/syntax-templates/notepad++/default.xml
+++ b/src/main/resources/syntax-templates/notepad++/default.xml
@@ -32,7 +32,7 @@
             <Keywords name="Keywords6">$</Keywords>
             <Keywords name="Keywords7">_</Keywords>
             <Keywords name="Keywords8">@</Keywords>
-            <Keywords name="Delimiters">00&apos; 01\ 02&apos; 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+            <Keywords name="Delimiters">00&apos; 01\ 02&apos; 03&quot; 04\ 05&quot; 06@{ 07 08} 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
             <WordsStyle name="DEFAULT" fgColor="FF0000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
@@ -52,8 +52,8 @@
             <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="FOLDER IN COMMENT" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS1" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="131076" />
+            <WordsStyle name="DELIMITERS3" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />

--- a/src/main/resources/syntax-templates/notepad++/obsidian.xml
+++ b/src/main/resources/syntax-templates/notepad++/obsidian.xml
@@ -32,7 +32,7 @@
             <Keywords name="Keywords6">$</Keywords>
             <Keywords name="Keywords7">_</Keywords>
             <Keywords name="Keywords8">@</Keywords>
-            <Keywords name="Delimiters">00&apos; 01\ 02&apos; 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+            <Keywords name="Delimiters">00&apos; 01\ 02&apos; 03&quot; 04\ 05&quot; 06@{ 07 08} 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
             <WordsStyle name="DEFAULT" fgColor="D2963E" bgColor="293134" fontName="" fontStyle="0" nesting="0" />
@@ -52,8 +52,8 @@
             <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
             <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS1" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS2" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS3" fgColor="FFFFFF" bgColor="293134" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="0" nesting="131076" />
+            <WordsStyle name="DELIMITERS3" fgColor="A082BD" bgColor="293134" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontStyle="0" nesting="0" />

--- a/src/main/resources/syntax-templates/notepad++/solarized_dark.xml
+++ b/src/main/resources/syntax-templates/notepad++/solarized_dark.xml
@@ -32,7 +32,7 @@
             <Keywords name="Keywords6">$</Keywords>
             <Keywords name="Keywords7">_</Keywords>
             <Keywords name="Keywords8">@</Keywords>
-            <Keywords name="Delimiters">00&apos; 01\ 02&apos; 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+            <Keywords name="Delimiters">00&apos; 01\ 02&apos; 03&quot; 04\ 05&quot; 06@{ 07 08} 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
             <WordsStyle name="DEFAULT" fgColor="2AA198" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
@@ -52,8 +52,8 @@
             <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="FOLDER IN COMMENT" fgColor="008000" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS1" fgColor="CB4B16" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS2" fgColor="000000" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="CB4B16" bgColor="002B36" fontName="" fontStyle="0" nesting="131076" />
+            <WordsStyle name="DELIMITERS3" fgColor="D33682" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="002B36" fontName="" fontStyle="0" nesting="0" />

--- a/src/main/resources/syntax-templates/notepad++/solarized_light.xml
+++ b/src/main/resources/syntax-templates/notepad++/solarized_light.xml
@@ -32,7 +32,7 @@
             <Keywords name="Keywords6">$</Keywords>
             <Keywords name="Keywords7">_</Keywords>
             <Keywords name="Keywords8">@</Keywords>
-            <Keywords name="Delimiters">00&apos; 01\ 02&apos; 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+            <Keywords name="Delimiters">00&apos; 01\ 02&apos; 03&quot; 04\ 05&quot; 06@{ 07 08} 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>
         <Styles>
             <WordsStyle name="DEFAULT" fgColor="2AA198" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
@@ -52,8 +52,8 @@
             <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="FOLDER IN COMMENT" fgColor="008000" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS1" fgColor="CB4B16" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS2" fgColor="000000" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="DELIMITERS3" fgColor="000000" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="CB4B16" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="131076" />
+            <WordsStyle name="DELIMITERS3" fgColor="D33682" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FDF6E3" fontName="" fontStyle="0" nesting="0" />


### PR DESCRIPTION
I made double quoted strings highlight like single quoted strings, and then gave a nested exception to @ keyword and @{} delimiter. It's not perfect, but this is the closest I could get it. It highlights vars in smart strings in almost all cases, except for @ when not a prefix -- eg. "word@var". However, "word@{var}word" and "word @var word" work as expected.