### PR TITLE
Faster matching for procedures

### DIFF
--- a/src/main/java/com/laytonsmith/core/Script.java
+++ b/src/main/java/com/laytonsmith/core/Script.java
@@ -265,7 +265,7 @@ public class Script {
         CurrentEnv.getEnv(GlobalEnv.class).SetLabel(this.label);
         if (m.getCType() == ConstructType.FUNCTION) {
                 env.getEnv(GlobalEnv.class).SetScript(this);
-                if (m.val().matches("^_[^_].*")) {
+                if (m.val().charAt(0) == '_' && m.val().charAt(1) != '_') {
                     //Not really a function, so we can't put it in Function.
                     Procedure p = getProc(m.val());
                     if (p == null) {


### PR DESCRIPTION
I discovered this simple little bottleneck when testing scripts with WarmRoast. 

When running the below test script, it consistently ran for 44-45 seconds before the optimization, and ran consistently for 33-34 seconds after the optimization. So over several runs it ran about 34% faster for this particular test, but given the location of the optimization we should see similar results for many scripts.

```
*:/test = >>>
	@start = time();
	for(@x = 0, @x < 300, @x++) {
		for(@y = 1, @y < 100, @y++) {
			for(@z = 0, @z < 300, @z++) {
				get_block_at(@x, @y, @z, 'world');
			}
		}
	}
	@stop = time();
	msg((@stop - @start).'ms');
<<<
```