### PR TITLE
Fix various stacktraces, crashes, incompletenesses.

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCCommand.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCCommand.java
@@ -16,8 +16,10 @@ import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
+import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.events.Driver;
 import com.laytonsmith.core.events.EventUtils;
+import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.exceptions.FunctionReturnException;
 import com.laytonsmith.core.functions.Commands;
 import java.util.ArrayList;
@@ -262,6 +264,9 @@ public class BukkitMCCommand implements MCCommand {
 				if (fret instanceof CBoolean) {
 					return ((CBoolean) fret).getBoolean();
 				}
+			} catch (ConfigRuntimeException cre) {
+				cre.setEnv(closure.getEnv());
+				ConfigRuntimeException.HandleUncaughtException(cre, closure.getEnv());
 			}
 			return true;
 		} else {

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCObjective.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/BukkitMCObjective.java
@@ -72,7 +72,11 @@ public class BukkitMCObjective implements MCObjective {
 
 	@Override
 	public void setDisplaySlot(MCDisplaySlot slot) {
-		o.setDisplaySlot(BukkitMCDisplaySlot.getConvertor().getConcreteEnum(slot));
+		if (slot == null) {
+			o.setDisplaySlot(null);
+		} else {
+			o.setDisplaySlot(BukkitMCDisplaySlot.getConvertor().getConcreteEnum(slot));
+		}
 	}
 
 	@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitBlockEvents.java
@@ -37,6 +37,9 @@ import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.Target;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.laytonsmith.core.exceptions.ConfigRuntimeException;
+import com.laytonsmith.core.functions.Exceptions.ExceptionType;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
@@ -376,7 +379,13 @@ public class BukkitBlockEvents {
 
 		@Override
 		public void setItem(MCItemStack item) {
-			bde.setItem(((BukkitMCItemStack) item).asItemStack());
+			if (item == null || item.getType().getName() == "AIR") {
+				throw new ConfigRuntimeException("Due to Bukkit's handling of this event, the item cannot be set to null."
+						+ " Until they change this, workaround by cancelling the event and manipulating the block"
+						+ " using inventory functions.", ExceptionType.IllegalArgumentException, Target.UNKNOWN);
+			} else {
+				bde.setItem(((BukkitMCItemStack) item).asItemStack());
+			}
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitVehicleEvents.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/BukkitVehicleEvents.java
@@ -142,9 +142,9 @@ public class BukkitVehicleEvents {
 		}
 
 		@Override
-		public MCVehicle getVehicle() {
+		public MCEntity getVehicle() {
 			if (ve.getVehicle() instanceof org.bukkit.entity.Vehicle) {
-				return (MCVehicle) BukkitConvertor.BukkitGetCorrectEntity(ve.getVehicle());
+				return BukkitConvertor.BukkitGetCorrectEntity(ve.getVehicle());
 			}
 			return null;
 		}

--- a/src/main/java/com/laytonsmith/abstraction/events/MCVehicleEvent.java
+++ b/src/main/java/com/laytonsmith/abstraction/events/MCVehicleEvent.java
@@ -1,8 +1,8 @@
 package com.laytonsmith.abstraction.events;
 
-import com.laytonsmith.abstraction.MCVehicle;
+import com.laytonsmith.abstraction.MCEntity;
 import com.laytonsmith.core.events.BindableEvent;
 
 public interface MCVehicleEvent extends BindableEvent {
-	public MCVehicle getVehicle();
+	public MCEntity getVehicle();
 }

--- a/src/main/java/com/laytonsmith/core/functions/Commands.java
+++ b/src/main/java/com/laytonsmith/core/functions/Commands.java
@@ -59,7 +59,7 @@ public class Commands {
 			MCServer s = Static.getServer();
 			MCCommand cmd = s.getCommandMap().getCommand(args[0].val());
 			if (cmd == null) {
-				throw new ConfigRuntimeException("Command not found did you forget to register it?",
+				throw new ConfigRuntimeException("Command not found, did you forget to register it?",
 						ExceptionType.NotFoundException, t);
 			}
 			customExec(t, environment, cmd, args[1]);
@@ -181,11 +181,11 @@ public class Commands {
 		@Override
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
 			MCCommandMap map = Static.getServer().getCommandMap();
-			MCCommand cmd = map.getCommand(args[0].val());
+			MCCommand cmd = map.getCommand(args[0].val().toLowerCase());
 			boolean isnew = false;
 			if (cmd == null) {
 				isnew = true;
-				cmd = StaticLayer.GetConvertor().getNewCommand(args[0].val());
+				cmd = StaticLayer.GetConvertor().getNewCommand(args[0].val().toLowerCase());
 			}
 			if (args[1] instanceof CArray) {
 				CArray ops = (CArray) args[1];

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -185,7 +185,9 @@ public class PlayerManagement {
 
 		@Override
 		public String docs() {
-			return "UUID {[player]} Returns the uuid of the current player or the specified player.";
+			return "UUID {[player]} Returns the uuid of the current player or the specified player."
+					+ " This will attempt to find an offline player, but if that also fails,"
+					+ " a PlayerOfflineException will be thrown.";
 		}
 
 		@Override

--- a/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
+++ b/src/main/java/com/laytonsmith/core/functions/Scoreboards.java
@@ -82,7 +82,7 @@ public class Scoreboards {
 	/**
 	 * Adds a scoreboard to the cache
 	 * @param id The name to save the new scoreboard as
-	 * @param board Scoreboard, either from {@link MCServer#getNewScoreboard} or {@link MCPlayer#getScoreboard()}
+	 * @param board Scoreboard, either from {@link com.laytonsmith.abstraction.MCServer#getNewScoreboard()} or {@link MCPlayer#getScoreboard()}
 	 * @param t
 	 * @throws ConfigRuntimeException if the cache already contains the board or the id
 	 */
@@ -788,12 +788,12 @@ public class Scoreboards {
 			}
 			if (nullify) {
 				MCScoreboard s = getBoard(id, t);
-				for (String p : s.getEntries()) {
-					s.resetScores(p);
-					try {
-						Static.GetPlayer(p, t).setScoreboard(getBoard(MAIN, t));
-					} catch (ConfigRuntimeException ex){
-						// Not an exception in this case
+				for (String e : s.getEntries()) {
+					s.resetScores(e);
+				}
+				for (MCPlayer p : Static.getServer().getOnlinePlayers()) {
+					if (s.equals(p.getScoreboard())) {
+						p.setScoreboard(getBoard(MAIN, t));
 					}
 				}
 				for (MCTeam g : s.getTeams()) {


### PR DESCRIPTION
CMDHELPER-2686 fixed
CMDHELPER-2877 fixed
CMDHELPER-2916 addressed
CMDHELPER-2929 addressed
CMDHELPER-3046 fixed

Also fixes unhelpful stacktraces being thrown from CREs in registered commands. These have been replaced with normal CH error reports with accurate script info.