### PR TITLE
Fixed array_get's deep cloning.

### DIFF
--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -572,17 +572,25 @@ public class CArray extends Construct implements ArrayAccess{
     }
 	
 	public CArray deepClone(Target t) {
-		return deepClone(this, t);
+		CArray clone = deepClone(this, t, new ArrayList<CArray[]>());
+		return clone;
 	}
 	
-	private static CArray deepClone(CArray array, Target t) {
+	private static CArray deepClone(CArray array, Target t, ArrayList<CArray[]> cloneRefs) {
 		CArray clone = new CArray(t, (int) array.size());
 		clone.associative_mode = array.associative_mode;
 		for (Iterator<Construct> it = array.keySet().iterator(); it.hasNext();) {
 			Construct key = it.next();
 			Construct value = array.get(key, t);
 			if(value instanceof CArray) {
-				value = deepClone((CArray) value, t);
+				for(CArray[] refCouple : cloneRefs) {
+					if(refCouple[0] == array) {
+						value = refCouple[1];
+						break;
+					}
+					cloneRefs.add(new CArray[] {array, clone});
+					value = deepClone((CArray) value, t, cloneRefs);
+				}
 			}
 			clone.set(key, value, t);
 		}

--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -570,6 +570,24 @@ public class CArray extends Construct implements ArrayAccess{
         clone.regenValue(new HashSet<CArray>());
         return clone;
     }
+	
+	public CArray deepClone(Target t) {
+		return deepClone(this, t);
+	}
+	
+	private static CArray deepClone(CArray array, Target t) {
+		CArray clone = new CArray(t, (int) array.size());
+		clone.associative_mode = array.associative_mode;
+		for (Iterator<Construct> it = array.keySet().iterator(); it.hasNext();) {
+			Construct key = it.next();
+			Construct value = array.get(key, t);
+			if(value instanceof CArray) {
+				value = deepClone((CArray) value, t);
+			}
+			clone.set(key, value, t);
+		}
+		return clone;
+	}
 
     private String normalizeConstruct(Construct c){
         if(c instanceof CArray){

--- a/src/main/java/com/laytonsmith/core/constructs/CArray.java
+++ b/src/main/java/com/laytonsmith/core/constructs/CArray.java
@@ -577,20 +577,24 @@ public class CArray extends Construct implements ArrayAccess{
 	}
 	
 	private static CArray deepClone(CArray array, Target t, ArrayList<CArray[]> cloneRefs) {
+		
+		// Return the clone reference if this array has been cloned before (both clones will have the same reference).
+		for(CArray[] refCouple : cloneRefs) {
+			if(refCouple[0] == array) {
+				return refCouple[1];
+			}
+		}
+		
+		// Create the clone to put array in and add it to the cloneRefs list.
 		CArray clone = new CArray(t, (int) array.size());
 		clone.associative_mode = array.associative_mode;
-		for (Iterator<Construct> it = array.keySet().iterator(); it.hasNext();) {
-			Construct key = it.next();
+		cloneRefs.add(new CArray[] {array, clone});
+		
+		// Iterate over the array, recursively calling this method to perform a deep clone.
+		for (Construct key : array.keySet()) {
 			Construct value = array.get(key, t);
 			if(value instanceof CArray) {
-				for(CArray[] refCouple : cloneRefs) {
-					if(refCouple[0] == array) {
-						value = refCouple[1];
-						break;
-					}
-					cloneRefs.add(new CArray[] {array, clone});
-					value = deepClone((CArray) value, t, cloneRefs);
-				}
+				value = deepClone((CArray) value, t, cloneRefs);
 			}
 			clone.set(key, value, t);
 		}

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -146,6 +146,8 @@ public class ArrayHandling {
 					// Deep clone the array if the "index" is the initial one.
 					if (((CSlice) index).getStart() == 0 && ((CSlice) index).getFinish() == -1) {
 						return ca.deepClone(t);
+					} else if(ca.inAssociativeMode()) {
+						throw new ConfigRuntimeException("Array slices are not allowed with an associative array", ExceptionType.CastException, t);
 					}
 					
 					//It's a range

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -2248,12 +2248,21 @@ public class ArrayHandling {
 			return CHVersion.V3_3_1;
 		}
 
-//		@Override
-//		public ExampleScript[] examples() throws ConfigCompileException {
-//			return new ExampleScript[]{
-//				new ExampleScript("", "")
-//			};
-//		}
+		@Override
+		public ExampleScript[] examples() throws ConfigCompileException {
+			return new ExampleScript[]{
+				new ExampleScript("Demonstrates that the array is cloned.",
+						"@array = array(1, 2, 3, 4)\n" +
+						"@deepClone = array_deep_clone(@array)\n" +
+						"@deepClone[1] = 'newValue'\n" +
+						"msg(@array)\nmsg(@deepClone)"),
+				new ExampleScript("Demonstrated that arrays within the array are also cloned by a deep clone.",
+						"@array = array(array('value'))\n" +
+						"@deepClone = array_deep_clone(@array)\n" +
+						"@deepClone[0][0] = 'newValue'\n" +
+						"msg(@array)\nmsg(@deepClone)")
+			};
+		}
 
 	}
 	
@@ -2311,12 +2320,21 @@ public class ArrayHandling {
 			return CHVersion.V3_3_1;
 		}
 
-//		@Override
-//		public ExampleScript[] examples() throws ConfigCompileException {
-//			return new ExampleScript[]{
-//				new ExampleScript("", "")
-//			};
-//		}
+		@Override
+		public ExampleScript[] examples() throws ConfigCompileException {
+			return new ExampleScript[]{
+				new ExampleScript("Demonstrates that the array is cloned.",
+						"@array = array(1, 2, 3, 4)\n" +
+						"@shallowClone = array_shallow_clone(@array)\n" +
+						"@shallowClone[1] = 'newValue'\n" +
+						"msg(@array)\nmsg(@shallowClone)"),
+				new ExampleScript("Demonstrated that arrays within the array are not cloned by a shallow clone.",
+						"@array = array(array('value'))\n" +
+						"@shallowClone = array_shallow_clone(@array)\n" +
+						"@shallowClone[0][0] = 'newValue'\n" +
+						"msg(@array)\nmsg(@shallowClone)")
+			};
+		}
 
 	}
 }

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -2196,56 +2196,125 @@ public class ArrayHandling {
 
 	}
 
-//	@api
-//	public static class array_deep_clone extends AbstractFunction {
-//
-//		@Override
-//		public ExceptionType[] thrown() {
-//			return new ExceptionType[]{ExceptionType.CastException};
-//		}
-//
-//		@Override
-//		public boolean isRestricted() {
-//			return false;
-//		}
-//
-//		@Override
-//		public Boolean runAsync() {
-//			return null;
-//		}
-//
-//		@Override
-//		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
-//			throw new UnsupportedOperationException("TODO: Not supported yet.");
-//		}
-//
-//		@Override
-//		public String getName() {
-//			return "array_deep_clone";
-//		}
-//
-//		@Override
-//		public Integer[] numArgs() {
-//			return new Integer[]{1};
-//		}
-//
-//		@Override
-//		public String docs() {
-//			return "array {array} Performs a deep clone on an array (as opposed to a shallow clone). This is useful"
-//					+ " for multidimensional arrays. See the examples for more info.";
-//		}
-//
-//		@Override
-//		public Version since() {
-//			return CHVersion.V3_3_1;
-//		}
-//
+	@api
+	public static class array_deep_clone extends AbstractFunction {
+
+		@Override
+		public ExceptionType[] thrown() {
+			return new ExceptionType[]{ExceptionType.CastException, ExceptionType.InsufficientArgumentsException};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return false;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
+			if(args.length != 1) {
+				throw new ConfigRuntimeException("Expecting exactly one argument", ExceptionType.InsufficientArgumentsException, t);
+			}
+			if(!(args[0] instanceof CArray)) {
+				throw new ConfigRuntimeException("Expecting argument 1 to be an array", ExceptionType.CastException, t);
+			}
+			return ((CArray) args[0]).deepClone(t);
+		}
+
+		@Override
+		public String getName() {
+			return "array_deep_clone";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{1};
+		}
+
+		@Override
+		public String docs() {
+			return "array {array} Performs a deep clone on an array (as opposed to a shallow clone). This is useful"
+					+ " for multidimensional arrays. See the examples for more info.";
+		}
+
+		@Override
+		public Version since() {
+			return CHVersion.V3_3_1;
+		}
+
 //		@Override
 //		public ExampleScript[] examples() throws ConfigCompileException {
 //			return new ExampleScript[]{
 //				new ExampleScript("", "")
 //			};
 //		}
-//
-//	}
+
+	}
+	
+	@api
+	public static class array_shallow_clone extends AbstractFunction {
+
+		@Override
+		public ExceptionType[] thrown() {
+			return new ExceptionType[]{ExceptionType.CastException, ExceptionType.InsufficientArgumentsException};
+		}
+
+		@Override
+		public boolean isRestricted() {
+			return false;
+		}
+
+		@Override
+		public Boolean runAsync() {
+			return null;
+		}
+
+		@Override
+		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
+			if(args.length != 1) {
+				throw new ConfigRuntimeException("Expecting exactly one argument", ExceptionType.InsufficientArgumentsException, t);
+			}
+			if(!(args[0] instanceof CArray)) {
+				throw new ConfigRuntimeException("Expecting argument 1 to be an array", ExceptionType.CastException, t);
+			}
+			CArray array = (CArray) args[0];
+			CArray shallowClone = (array.isAssociative() ? CArray.GetAssociativeArray(t) : new CArray(t));
+			for(Construct key : array.keySet()) {
+				shallowClone.set(key, array.get(key, t), t);
+			}
+			return shallowClone;
+		}
+
+		@Override
+		public String getName() {
+			return "array_shallow_clone";
+		}
+
+		@Override
+		public Integer[] numArgs() {
+			return new Integer[]{1};
+		}
+
+		@Override
+		public String docs() {
+			return "array {array} Performs a shallow clone on an array (as opposed to a deep clone). See the examples for more info.";
+		}
+
+		@Override
+		public Version since() {
+			return CHVersion.V3_3_1;
+		}
+
+//		@Override
+//		public ExampleScript[] examples() throws ConfigCompileException {
+//			return new ExampleScript[]{
+//				new ExampleScript("", "")
+//			};
+//		}
+
+	}
 }

--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -8,9 +8,7 @@ import com.laytonsmith.abstraction.StaticLayer;
 import com.laytonsmith.annotations.api;
 import com.laytonsmith.annotations.core;
 import com.laytonsmith.annotations.seealso;
-import com.laytonsmith.core.CHLog;
 import com.laytonsmith.core.CHVersion;
-import com.laytonsmith.core.LogLevel;
 import com.laytonsmith.core.Optimizable;
 import com.laytonsmith.core.ParseTree;
 import com.laytonsmith.core.Script;
@@ -144,21 +142,12 @@ public class ArrayHandling {
 			if (args[0] instanceof CArray) {
 				CArray ca = (CArray) args[0];
 				if (index instanceof CSlice) {
-					if (ca.inAssociativeMode()) {
-						if (((CSlice) index).getStart() == 0 && ((CSlice) index).getFinish() == -1) {
-							//Special exception, we want to clone the whole array
-							CArray na = CArray.GetAssociativeArray(t);
-							for (Construct key : ca.keySet()) {
-								try {
-									na.set(key, ca.get(key, t).clone(), t);
-								} catch (CloneNotSupportedException ex) {
-									na.set(key, ca.get(key, t), t);
-								}
-							}
-							return na;
-						}
-						throw new ConfigRuntimeException("Array slices are not allowed with an associative array", ExceptionType.CastException, t);
+						
+					// Deep clone the array if the "index" is the initial one.
+					if (((CSlice) index).getStart() == 0 && ((CSlice) index).getFinish() == -1) {
+						return ca.deepClone(t);
 					}
+					
 					//It's a range
 					long start = ((CSlice) index).getStart();
 					long finish = ((CSlice) index).getFinish();

--- a/src/test/java/com/laytonsmith/core/functions/ArrayHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/ArrayHandlingTest.java
@@ -10,7 +10,6 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.CommandHelperEnvironment;
 import com.laytonsmith.core.exceptions.CancelCommandException;
-import com.laytonsmith.core.exceptions.ConfigCompileException;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.testing.C;
 import com.laytonsmith.testing.StaticTest;
@@ -306,4 +305,20 @@ public class ArrayHandlingTest {
 	@Test public void testArrayUnique4() throws Exception {
 		assertEquals("{1, 1}", SRun("array_unique(array(1, '1', 1), true)", fakePlayer));
 	}
+	
+	@Test public void testArrayGetClone() throws Exception {
+		Run("@a = array(array(array('value'))); @b = @a[]; @b[0][0][0] = 'changedValue'; msg(@a[0][0][0]);", fakePlayer);
+		verify(fakePlayer).sendMessage("value");
+	}
+	
+	@Test public void testArrayGetCloneRefCouples() throws Exception {
+		Run("@a = array('Meow'); @b = array(@a, @a, array(@a)); @c = @b[]; msg((ref_equals(@b[0], @b[1]) && ref_equals(@b[0], @b[2][0])));", fakePlayer);
+		verify(fakePlayer).sendMessage("true");
+	}
+	
+	@Test public void testArrayGetCloneRecursiveArray() throws Exception {
+		Run("@a = array(); @b = array(); @a[0] = @b; @b[0] = @a; @c = @a[]; msg((ref_equals(@c[0], @c[0][0][0]) && ref_equals(@c, @c[0][0])));", fakePlayer);
+		verify(fakePlayer).sendMessage("true");
+	}
+	
 }

--- a/src/test/java/com/laytonsmith/core/functions/ArrayHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/ArrayHandlingTest.java
@@ -307,12 +307,13 @@ public class ArrayHandlingTest {
 	}
 	
 	@Test public void testArrayGetClone() throws Exception {
-		Run("@a = array(array(array('value'))); @b = @a[]; @b[0][0][0] = 'changedValue'; msg(@a[0][0][0]);", fakePlayer);
+		Run("@a = array(array(array('value'))); @b = @a[]; @b[0][0][0] = 'changedValue'; msg(@a[0][0][0]); msg(@b[0][0][0]);", fakePlayer);
 		verify(fakePlayer).sendMessage("value");
+		verify(fakePlayer).sendMessage("changedValue");
 	}
 	
 	@Test public void testArrayGetCloneRefCouples() throws Exception {
-		Run("@a = array('Meow'); @b = array(@a, @a, array(@a)); @c = @b[]; msg((ref_equals(@b[0], @b[1]) && ref_equals(@b[0], @b[2][0])));", fakePlayer);
+		Run("@a = array('Meow'); @b = array(@a, @a, array(@a)); @c = @b[]; msg((ref_equals(@c[0], @c[1]) && ref_equals(@c[0], @c[2][0])));", fakePlayer);
 		verify(fakePlayer).sendMessage("true");
 	}
 	

--- a/src/test/java/com/laytonsmith/core/functions/ArrayHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/ArrayHandlingTest.java
@@ -306,9 +306,23 @@ public class ArrayHandlingTest {
 		assertEquals("{1, 1}", SRun("array_unique(array(1, '1', 1), true)", fakePlayer));
 	}
 	
-	@Test public void testArrayGetClone() throws Exception {
+	@Test public void testArrayGetClone() throws Exception { // This is expected to be a deep clone.
 		Run("@a = array(array(array('value'))); @b = @a[]; @b[0][0][0] = 'changedValue'; msg(@a[0][0][0]); msg(@b[0][0][0]);", fakePlayer);
 		verify(fakePlayer).sendMessage("value");
+		verify(fakePlayer).sendMessage("changedValue");
+	}
+	
+	@Test public void testArrayDeepClone() throws Exception {
+		Run("@a = array(array(array('value'))); @b = array_deep_clone(@a); @b[0][0][0] = 'changedValue'; msg(@a[0][0][0]); msg(@b[0][0][0]);", fakePlayer);
+		verify(fakePlayer).sendMessage("value");
+		verify(fakePlayer).sendMessage("changedValue");
+	}
+	
+	@Test public void testArrayShallowClone() throws Exception {
+		Run("@a = array(array('value')); @b = array_shallow_clone(@a); @b[0][0] = 'changedValue'; msg(equals(@a[0][0], @b[0][0]));"
+				+ "msg(ref_equals(@a, @b)); msg(@a[0][0])", fakePlayer);
+		verify(fakePlayer).sendMessage("true");
+		verify(fakePlayer).sendMessage("false");
 		verify(fakePlayer).sendMessage("changedValue");
 	}
 	

--- a/src/test/java/com/laytonsmith/core/functions/StringHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/StringHandlingTest.java
@@ -177,7 +177,7 @@ public class StringHandlingTest {
 		}
 
 		//A few advanced usages
-		assertEquals("004.000", SRun("sprintf('%07.3f', 4)", null));
+		assertEquals("004,000", SRun("sprintf('%07.3f', 4)", null));
 
 		long s = System.currentTimeMillis();
 		assertEquals(String.format("%1$tm %1$te,%1$tY", s), SRun("sprintf('%1$tm %1$te,%1$tY', " + Long.toString(s) + ")", null));

--- a/src/test/java/com/laytonsmith/core/functions/StringHandlingTest.java
+++ b/src/test/java/com/laytonsmith/core/functions/StringHandlingTest.java
@@ -177,7 +177,7 @@ public class StringHandlingTest {
 		}
 
 		//A few advanced usages
-		assertEquals("004,000", SRun("sprintf('%07.3f', 4)", null));
+		assertEquals("004.000", SRun("sprintf('%07.3f', 4)", null));
 
 		long s = System.currentTimeMillis();
 		assertEquals(String.format("%1$tm %1$te,%1$tY", s), SRun("sprintf('%1$tm %1$te,%1$tY', " + Long.toString(s) + ")", null));


### PR DESCRIPTION
- array_get(@array) or @array[] only cloned 2 arrays deep. It will now recursively clone the whole array.
- Added array_deep_clone(@array).
- Added array_shallow_clone(@array).