### PR TITLE
Add missing game rules to MCGameRule enum

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/enums/MCGameRule.java
+++ b/src/main/java/com/laytonsmith/abstraction/enums/MCGameRule.java
@@ -11,13 +11,19 @@ import com.laytonsmith.annotations.MEnum;
 public enum MCGameRule {
 	COMMANDBLOCKOUTPUT("commandBlockOutput"),
 	DODAYLIGHTCYCLE("doDaylightCycle"),
+	DOENTITYDROPS("doEntityDrops"),
 	DOFIRETICK("doFireTick"),
 	DOMOBLOOT("doMobLoot"),
 	DOMOBSPAWNING("doMobSpawning"),
 	DOTILEDROPS("doTileDrops"),
 	KEEPINVENTORY("keepInventory"),
+	LOGADMINCOMMANDS("logAdminCommands"),
 	MOBGRIEFING("mobGriefing"),
-	NATURALREGENERATION("naturalRegeneration");
+	NATURALREGENERATION("naturalRegeneration"),
+	RANDOMTICKSPEED("randomTickSpeed"),
+	REDUCEDDEBUGINFO("reducedDebugInfo"),
+	SENDCOMMANDFEEDBACK("sendCommandFeedback"),
+	SHOWDEATHMESSAGES("showDeathMessages");
 
 	private final String gameRule;
 


### PR DESCRIPTION
There's a few missing game rules in the `MCGameRule` enum (notably `DOENTITYDROPS`) - this adds them!  :+1: 

See also: http://minecraft.gamepedia.com/Commands#gamerule