### PR TITLE
Add uptime and gc stats to get_server_info

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -812,9 +812,9 @@ public class Minecraft {
 					+ "<li>11 - Server port; Get the game port that the server runs on</li>"
 					+ "<li>12 - Server IP; Get the IP that the server runs on</li>"
 					+ "<li>13 - Uptime; The number of milliseconds the server has been running</li>"
-					+ "<li>14 - gcmax; The maximum amount of memory that the Java virtual machine will attempt to use</li>"
-					+ "<li>15 - gctotal; The total amount of memory in the Java virtual machine</li>"
-					+ "<li>16 - gcfree; The amount of free memory in the Java Virtual Machine</li></ul>";
+					+ "<li>14 - gcmax; The maximum amount of memory that the Java virtual machine will attempt to use, in bytes</li>"
+					+ "<li>15 - gctotal; The total amount of memory in the Java virtual machine, in bytes</li>"
+					+ "<li>16 - gcfree; The amount of free memory in the Java Virtual Machine, in bytes</li></ul>";
 		}
 
 		@Override
@@ -936,15 +936,15 @@ public class Minecraft {
 			}
 			if (index == 14 || index == -1) {
 				//gcmax
-				retVals.add(new CInt((Runtime.getRuntime().maxMemory() / 1024 / 1024), t));
+				retVals.add(new CInt((Runtime.getRuntime().maxMemory()), t));
 			}
 			if (index == 15 || index == -1) {
 				//gctotal
-				retVals.add(new CInt((Runtime.getRuntime().totalMemory() / 1024 / 1024), t));
+				retVals.add(new CInt((Runtime.getRuntime().totalMemory()), t));
 			}
 			if (index == 16 || index == -1) {
 				//gcfree
-				retVals.add(new CInt((Runtime.getRuntime().freeMemory() / 1024 / 1024), t));
+				retVals.add(new CInt((Runtime.getRuntime().freeMemory()), t));
 			}
 
 			if (retVals.size() == 1) {

--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -931,7 +931,7 @@ public class Minecraft {
 			}
 			if (index == 13 || index == -1) {
 				//Uptime
-				double uptime = (double)(new GregorianCalendar().getTimeInMillis() - ManagementFactory.getRuntimeMXBean().getStartTime());
+				double uptime = (double)(System.currentTimeMillis() - ManagementFactory.getRuntimeMXBean().getStartTime());
 				retVals.add(new CDouble(uptime, t));
 			}
 			if (index == 14 || index == -1) {

--- a/src/main/java/com/laytonsmith/core/functions/Minecraft.java
+++ b/src/main/java/com/laytonsmith/core/functions/Minecraft.java
@@ -54,10 +54,13 @@ import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.Exceptions.ExceptionType;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.Enumeration;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -807,7 +810,11 @@ public class Minecraft {
 					+ "<li>9 - Plugins; An array of plugins loaded by the server.</li>"
 					+ "<li>10 - Online Mode; If true, users are authenticated with Mojang before login</li>"
 					+ "<li>11 - Server port; Get the game port that the server runs on</li>"
-					+ "<li>12 - Server IP; Get the IP that the server runs on</li></ul>";
+					+ "<li>12 - Server IP; Get the IP that the server runs on</li>"
+					+ "<li>13 - Uptime; The number of milliseconds the server has been running</li>"
+					+ "<li>14 - gcmax; The maximum amount of memory that the Java virtual machine will attempt to use</li>"
+					+ "<li>15 - gctotal; The total amount of memory in the Java virtual machine</li>"
+					+ "<li>16 - gcfree; The amount of free memory in the Java Virtual Machine</li></ul>";
 		}
 
 		@Override
@@ -921,6 +928,23 @@ public class Minecraft {
 			if (index == 12 || index == -1) {
 				//Server Ip
 				retVals.add(new CString(server.getIp(), t));
+			}
+			if (index == 13 || index == -1) {
+				//Uptime
+				double uptime = (double)(new GregorianCalendar().getTimeInMillis() - ManagementFactory.getRuntimeMXBean().getStartTime());
+				retVals.add(new CDouble(uptime, t));
+			}
+			if (index == 14 || index == -1) {
+				//gcmax
+				retVals.add(new CInt((Runtime.getRuntime().maxMemory() / 1024 / 1024), t));
+			}
+			if (index == 15 || index == -1) {
+				//gctotal
+				retVals.add(new CInt((Runtime.getRuntime().totalMemory() / 1024 / 1024), t));
+			}
+			if (index == 16 || index == -1) {
+				//gcfree
+				retVals.add(new CInt((Runtime.getRuntime().freeMemory() / 1024 / 1024), t));
 			}
 
 			if (retVals.size() == 1) {


### PR DESCRIPTION
This is a partial implementation of http://youtrack.sk89q.com/issue/CMDHELPER-2641

TPS still isn't there, and it looks like it takes a loop to measure it (Essentials implementation here: https://github.com/essentials/Essentials/blob/a2c43d822c66e617a84df9a8f074b9c3a3e32fae/Essentials/src/com/earth2me/essentials/EssentialsTimer.java).  Not sure if we want to do that or not.