### PR TITLE
Fixed error in core caused by pinfo.

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -867,9 +867,11 @@ public class PlayerManagement {
 				player = args[0].val();
 				index = Static.getInt32(args[1], t);
 			}
-
+			if(player == null) {
+				throw new ConfigRuntimeException(this.getName() + " has to be called from a player or with a player name as argument.", ExceptionType.InsufficientArgumentsException, t);
+			}
 			MCPlayer p = Static.GetPlayer(player, t);
-
+			
 			Static.AssertPlayerNonNull(p, t);
 			int maxIndex = 20;
 			if (index < -1 || index > maxIndex) {


### PR DESCRIPTION
When pinf() was used without arguments in a non-player environment (in
main.ms for example), it would cause a NullPointerException (error in
core). The exception will now be handled within the pinfo exec.