### PR TITLE
Handle null in Static.GetPlayer() again; Also fixes failed test.

### DIFF
--- a/src/main/java/com/laytonsmith/core/Static.java
+++ b/src/main/java/com/laytonsmith/core/Static.java
@@ -696,6 +696,11 @@ public final class Static {
 	 */
 	public static MCPlayer GetPlayer(String player, Target t) throws ConfigRuntimeException {
 		MCCommandSender m;
+
+		if (player == null) {
+			throw new ConfigRuntimeException("No player was specified!", ExceptionType.PlayerOfflineException, t);
+		}
+
 		if (player.length() > 0 && player.length() <= 16) {
 			m = GetCommandSender(player, t);
 		} else {

--- a/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
+++ b/src/main/java/com/laytonsmith/core/functions/PlayerManagement.java
@@ -868,9 +868,6 @@ public class PlayerManagement {
 				player = args[0].val();
 				index = Static.getInt32(args[1], t);
 			}
-			if(player == null) {
-				throw new ConfigRuntimeException(this.getName() + " has to be called from a player or with a player name as argument.", ExceptionType.InsufficientArgumentsException, t);
-			}
 			MCPlayer p = Static.GetPlayer(player, t);
 			
 			Static.AssertPlayerNonNull(p, t);


### PR DESCRIPTION
After jb-aero added UUID support to Static.GetPlayer(), it no longer handled null before checking the string length. This was the real source of the problem for the pinfo() fix. This may also fix other related cases.