### PR TITLE
Remove deprecated EventUtils.TriggerExternal() from most events to reduce overhead

### DIFF
--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitBlockListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitBlockListener.java
@@ -48,7 +48,6 @@ public class BukkitBlockListener implements Listener{
 		pistonsOut.add(e.getBlock());
 		
 		BukkitBlockEvents.BukkitMCBlockPistonExtendEvent mce = new BukkitBlockEvents.BukkitMCBlockPistonExtendEvent(e);
-		EventUtils.TriggerExternal(mce);
         EventUtils.TriggerListener(Driver.PISTON_EXTEND, "piston_extend", mce);
     }
 	
@@ -69,56 +68,48 @@ public class BukkitBlockListener implements Listener{
 		pistonsIn.add(e.getBlock());
 		
 		BukkitBlockEvents.BukkitMCBlockPistonRetractEvent mce = new BukkitBlockEvents.BukkitMCBlockPistonRetractEvent(e);
-		EventUtils.TriggerExternal(mce);
         EventUtils.TriggerListener(Driver.PISTON_RETRACT, "piston_retract", mce);
     }
 	
 	@EventHandler(priority=EventPriority.LOWEST)
     public void onSignChange(SignChangeEvent e){
 		BukkitBlockEvents.BukkitMCSignChangeEvent mce = new BukkitBlockEvents.BukkitMCSignChangeEvent(e);
-		EventUtils.TriggerExternal(mce);
         EventUtils.TriggerListener(Driver.SIGN_CHANGED, "sign_changed", mce);
     }
 	
 	@EventHandler(priority=EventPriority.LOWEST)
     public void onBlockPlace(BlockPlaceEvent e){
 		BukkitBlockEvents.BukkitMCBlockPlaceEvent bpe = new BukkitBlockEvents.BukkitMCBlockPlaceEvent(e);
-		EventUtils.TriggerExternal(bpe);
         EventUtils.TriggerListener(Driver.BLOCK_PLACE, "block_place", bpe);
     }
 	
 	@EventHandler(priority=EventPriority.LOWEST)
     public void onBlockBreak(BlockBreakEvent e){
 		BukkitBlockEvents.BukkitMCBlockBreakEvent bbe = new BukkitBlockEvents.BukkitMCBlockBreakEvent(e);
-		EventUtils.TriggerExternal(bbe);
         EventUtils.TriggerListener(Driver.BLOCK_BREAK, "block_break", bbe);
     }
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onBlockDispense(BlockDispenseEvent e) {
 		BukkitBlockEvents.BukkitMCBlockDispenseEvent bde = new BukkitBlockEvents.BukkitMCBlockDispenseEvent(e);
-		EventUtils.TriggerExternal(bde);
 		EventUtils.TriggerListener(Driver.BLOCK_DISPENSE, "block_dispense", bde);
 	}
 	
 	@EventHandler(priority=EventPriority.LOWEST)
 	public void onBlockBurn(BlockBurnEvent e){
 		BukkitBlockEvents.BukkitMCBlockBurnEvent bbe = new BukkitBlockEvents.BukkitMCBlockBurnEvent(e);
-		EventUtils.TriggerExternal(bbe);
 		EventUtils.TriggerListener(Driver.BLOCK_BURN, "block_burn", bbe);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onBlockIgnite(BlockIgniteEvent e) {
 		BukkitBlockEvents.BukkitMCBlockIgniteEvent bie = new BukkitBlockEvents.BukkitMCBlockIgniteEvent(e);
-		EventUtils.TriggerExternal(bie);
 		EventUtils.TriggerListener(Driver.BLOCK_IGNITE, "block_ignite", bie);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onBlockGrow(BlockGrowEvent e) {
 		BukkitBlockEvents.BukkitMCBlockGrowEvent bge = new BukkitBlockEvents.BukkitMCBlockGrowEvent(e);
-		EventUtils.TriggerExternal(bge);
 		EventUtils.TriggerListener(Driver.BLOCK_GROW, "block_grow", bge);
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitEntityListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitEntityListener.java
@@ -37,7 +37,6 @@ public class BukkitEntityListener implements Listener {
 	@EventIdentifier(event = Driver.CREATURE_SPAWN, className = "org.bukkit.event.entity.CreatureSpawnEvent")
 	public void onSpawn(Event event) {
 		BukkitMCCreatureSpawnEvent cse = new BukkitMCCreatureSpawnEvent(event);
-		EventUtils.TriggerExternal(cse);
 		EventUtils.TriggerListener(Driver.CREATURE_SPAWN, "creature_spawn", cse);
 	}
 
@@ -45,7 +44,6 @@ public class BukkitEntityListener implements Listener {
 			className = "org.bukkit.event.player.PlayerInteractEntityEvent")
 	public void onClickEnt(Event event) {
 		BukkitMCPlayerInteractEntityEvent piee = new BukkitMCPlayerInteractEntityEvent(event);
-		EventUtils.TriggerExternal(piee);
 		EventUtils.TriggerListener(Driver.PLAYER_INTERACT_ENTITY, "player_interact_entity", piee);
 	}
 
@@ -53,21 +51,18 @@ public class BukkitEntityListener implements Listener {
 			className = "org.bukkit.event.player.PlayerInteractAtEntityEvent")
 	public void onClickAtEnt(Event event) {
 		BukkitMCPlayerInteractAtEntityEvent piaee = new BukkitMCPlayerInteractAtEntityEvent(event);
-		EventUtils.TriggerExternal(piaee);
 		EventUtils.TriggerListener(Driver.PLAYER_INTERACT_AT_ENTITY, "player_interact_at_entity", piaee);
 	}
 
 	@EventIdentifier(event = Driver.ITEM_DROP, className = "org.bukkit.event.player.PlayerDropItemEvent")
 	public void onItemDrop(Event event) {
 		BukkitMCPlayerDropItemEvent pdie = new BukkitMCPlayerDropItemEvent(event);
-		EventUtils.TriggerExternal(pdie);
 		EventUtils.TriggerListener(Driver.ITEM_DROP, "item_drop", pdie);
     }
 
 	@EventIdentifier(event = Driver.ITEM_PICKUP, className = "org.bukkit.event.player.PlayerPickupItemEvent")
 	public void onItemPickup(Event event) {
 		BukkitMCPlayerPickupItemEvent ppie = new BukkitMCPlayerPickupItemEvent(event);
-		EventUtils.TriggerExternal(ppie);
 		EventUtils.TriggerListener(Driver.ITEM_PICKUP, "item_pickup", ppie);
 	}
 
@@ -79,7 +74,6 @@ public class BukkitEntityListener implements Listener {
 		} else {
 			ede = new BukkitMCEntityDeathEvent(event);
 		}
-		EventUtils.TriggerExternal(ede);
 		EventUtils.TriggerListener(Driver.ENTITY_DEATH, "entity_death", ede);
 		if (event instanceof PlayerDeathEvent) {
 			EventUtils.TriggerListener(Driver.PLAYER_DEATH, "player_death", ede);
@@ -89,7 +83,6 @@ public class BukkitEntityListener implements Listener {
 	@EventIdentifier(event = Driver.TARGET_ENTITY, className = "org.bukkit.event.entity.EntityTargetEvent")
 	public void onTargetLiving(Event event) {
 		BukkitMCTargetEvent ete = new BukkitMCTargetEvent(event);
-		EventUtils.TriggerExternal(ete);
         EventUtils.TriggerListener(Driver.TARGET_ENTITY, "target_player", ete);
     }
 
@@ -98,14 +91,12 @@ public class BukkitEntityListener implements Listener {
 		BukkitMCEntityDamageEvent ede;
 		if (event instanceof EntityDamageByEntityEvent) {
 			ede = new BukkitMCEntityDamageByEntityEvent(event);
-			EventUtils.TriggerExternal(ede);
 			EventUtils.TriggerListener(Driver.ENTITY_DAMAGE, "entity_damage", ede);
 			if (ede.getEntity() instanceof MCPlayer) {
 				EventUtils.TriggerListener(Driver.ENTITY_DAMAGE_PLAYER, "entity_damage_player", ede);
 			}
 		} else {
 			ede = new BukkitMCEntityDamageEvent(event);
-			EventUtils.TriggerExternal(ede);
 			EventUtils.TriggerListener(Driver.ENTITY_DAMAGE, "entity_damage", ede);
 		}
 	}
@@ -120,56 +111,48 @@ public class BukkitEntityListener implements Listener {
 	@EventIdentifier(event = Driver.PROJECTILE_LAUNCH, className = "org.bukkit.event.entity.ProjectileLaunchEvent")
 	public void onProjectileLaunch(Event event) {
 		BukkitMCProjectileLaunchEvent ple = new BukkitMCProjectileLaunchEvent(event);
-		EventUtils.TriggerExternal(ple);
 		EventUtils.TriggerListener(Driver.PROJECTILE_LAUNCH, "projectile_launch", ple);
 	}
 
 	@EventIdentifier(event = Driver.ENTITY_ENTER_PORTAL, className = "org.bukkit.event.entity.EntityPortalEnterEvent")
 	public void onPortalEnter(Event event) {
 		BukkitMCEntityEnterPortalEvent pe = new BukkitMCEntityEnterPortalEvent(event);
-		EventUtils.TriggerExternal(pe);
 		EventUtils.TriggerListener(Driver.ENTITY_ENTER_PORTAL, "entity_enter_portal", pe);
 	}
 
 	@EventIdentifier(event = Driver.ENTITY_EXPLODE, className = "org.bukkit.event.entity.EntityExplodeEvent")
 	public void onExplode(Event event) {
 		BukkitMCEntityExplodeEvent ee = new BukkitMCEntityExplodeEvent(event);
-		EventUtils.TriggerExternal(ee);
 		EventUtils.TriggerListener(Driver.ENTITY_EXPLODE, "entity_explode", ee);
 	}
 
 	@EventIdentifier(event = Driver.ITEM_DESPAWN, className = "org.bukkit.event.entity.ItemDespawnEvent")
 	public void onItemDespawn(Event event) {
 		BukkitMCItemDespawnEvent id = new BukkitMCItemDespawnEvent(event);
-		EventUtils.TriggerExternal(id);
 		EventUtils.TriggerListener(Driver.ITEM_DESPAWN, "item_despawn", id);
 	}
 
 	@EventIdentifier(event = Driver.ITEM_SPAWN, className = "org.bukkit.event.entity.ItemSpawnEvent")
 	public void onItemSpawn(Event event) {
 		BukkitMCItemSpawnEvent is = new BukkitMCItemSpawnEvent(event);
-		EventUtils.TriggerExternal(is);
 		EventUtils.TriggerListener(Driver.ITEM_SPAWN, "item_spawn", is);
 	}
 
 	@EventIdentifier(event = Driver.ENTITY_CHANGE_BLOCK, className = "org.bukkit.event.entity.EntityChangeBlockEvent")
 	public void onChangeBlock(Event event) {
 		BukkitMCEntityChangeBlockEvent ecbe = new BukkitMCEntityChangeBlockEvent(event);
-		EventUtils.TriggerExternal(ecbe);
 		EventUtils.TriggerListener(Driver.ENTITY_CHANGE_BLOCK, "entity_change_block", ecbe);
 	}
 
 	@EventIdentifier(event = Driver.ENTITY_INTERACT, className = "org.bukkit.event.entity.EntityInteractEvent")
 	public void onInteract(Event event) {
 		BukkitMCEntityInteractEvent eie = new BukkitMCEntityInteractEvent(event);
-		EventUtils.TriggerExternal(eie);
 		EventUtils.TriggerListener(Driver.ENTITY_INTERACT, "entity_interact", eie);
 	}
 
 	@EventIdentifier(event = Driver.HANGING_BREAK, className = "org.bukkit.event.hanging.HangingBreakEvent")
 	public void onHangingBreak(Event event) {
 		BukkitMCHangingBreakEvent hbe = new BukkitMCHangingBreakEvent(event);
-		EventUtils.TriggerExternal(hbe);
 		EventUtils.TriggerListener(Driver.HANGING_BREAK, "hanging_break", hbe);
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitInventoryListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitInventoryListener.java
@@ -32,14 +32,12 @@ public class BukkitInventoryListener implements Listener{
 	@EventHandler(priority=EventPriority.LOWEST)
 	public void onInvClick(InventoryClickEvent event) {
 		BukkitMCInventoryClickEvent ice = new BukkitInventoryEvents.BukkitMCInventoryClickEvent(event);
-		EventUtils.TriggerExternal(ice);
 		EventUtils.TriggerListener(Driver.INVENTORY_CLICK, "inventory_click", ice);
 	}
 
 	@EventHandler(priority=EventPriority.LOWEST)
 	public void onInvDrag(InventoryDragEvent event) {
 		BukkitMCInventoryDragEvent ide = new BukkitInventoryEvents.BukkitMCInventoryDragEvent(event);
-		EventUtils.TriggerExternal(ide);
 		EventUtils.TriggerListener(Driver.INVENTORY_DRAG, "inventory_drag", ide);
 	}
 	
@@ -60,28 +58,24 @@ public class BukkitInventoryListener implements Listener{
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onItemEnchant(EnchantItemEvent event) {
 		BukkitMCEnchantItemEvent eie = new BukkitInventoryEvents.BukkitMCEnchantItemEvent(event);
-		EventUtils.TriggerExternal(eie);
 		EventUtils.TriggerListener(Driver.ITEM_ENCHANT, "item_enchant", eie);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onPreEnchant(PrepareItemEnchantEvent event) {
 		BukkitMCPrepareItemEnchantEvent pie = new BukkitInventoryEvents.BukkitMCPrepareItemEnchantEvent(event);
-		EventUtils.TriggerExternal(pie);
 		EventUtils.TriggerListener(Driver.ITEM_PRE_ENCHANT, "item_pre_enchant", pie);
 	}
 	
 	@EventHandler(priority=EventPriority.LOWEST)
 	public void onItemHeld(PlayerItemHeldEvent event) {
 		BukkitMCItemHeldEvent ih = new BukkitInventoryEvents.BukkitMCItemHeldEvent(event);
-		EventUtils.TriggerExternal(ih);
 		EventUtils.TriggerListener(Driver.ITEM_HELD, "item_held", ih);
 	}
 	
 	@EventHandler(priority=EventPriority.LOWEST)
 	public void onPreCraft(PrepareItemCraftEvent event) {
 		BukkitMCPrepareItemCraftEvent pc = new BukkitInventoryEvents.BukkitMCPrepareItemCraftEvent(event);
-		EventUtils.TriggerExternal(pc);
 		EventUtils.TriggerListener(Driver.ITEM_PRE_CRAFT, "item_pre_craft", pc);
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitPlayerListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitPlayerListener.java
@@ -50,56 +50,48 @@ public class BukkitPlayerListener implements Listener {
 	@EventHandler(priority = EventPriority.LOWEST)
     public void onFoodLevelChange(FoodLevelChangeEvent e) {
 		BukkitPlayerEvents.BukkitMCFoodLevelChangeEvent pke = new BukkitPlayerEvents.BukkitMCFoodLevelChangeEvent(e);
-        //EventUtils.TriggerExternal(pke);
 		EventUtils.TriggerListener(Driver.FOOD_LEVEL_CHANGED, "food_level_changed", pke);
     }
 	
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerKick(PlayerKickEvent e) {
 		BukkitPlayerEvents.BukkitMCPlayerKickEvent pke = new BukkitPlayerEvents.BukkitMCPlayerKickEvent(e);
-        //EventUtils.TriggerExternal(pke);
 		EventUtils.TriggerListener(Driver.PLAYER_KICK, "player_kick", pke);
     }
 	
 	@EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerBedEnter(PlayerBedEnterEvent e) {
 		BukkitPlayerEvents.BukkitMCPlayerBedEvent be = new BukkitPlayerEvents.BukkitMCPlayerBedEvent(e);
-        //EventUtils.TriggerExternal(be);
 		EventUtils.TriggerListener(Driver.PLAYER_BED_EVENT, "player_enter_bed", be);
     }
 	
 	@EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerBedLeave(PlayerBedLeaveEvent e) {
 		BukkitPlayerEvents.BukkitMCPlayerBedEvent be = new BukkitPlayerEvents.BukkitMCPlayerBedEvent(e);
-        //EventUtils.TriggerExternal(be);
 		EventUtils.TriggerListener(Driver.PLAYER_BED_EVENT, "player_leave_bed", be);
     }
     
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerLogin(PlayerLoginEvent e) {
 		BukkitPlayerEvents.BukkitMCPlayerLoginEvent ple = new BukkitPlayerEvents.BukkitMCPlayerLoginEvent(e);
-		//EventUtils.TriggerExternal(ple);
 		EventUtils.TriggerListener(Driver.PLAYER_LOGIN, "player_login", ple);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerPreLogin(PlayerPreLoginEvent e) {
 		BukkitPlayerEvents.BukkitMCPlayerPreLoginEvent pple = new BukkitPlayerEvents.BukkitMCPlayerPreLoginEvent(e);
-		//EventUtils.TriggerExternal(pple);
 		EventUtils.TriggerListener(Driver.PLAYER_PRELOGIN, "player_prelogin", pple);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerJoin(PlayerJoinEvent e) {
 		BukkitPlayerEvents.BukkitMCPlayerJoinEvent pje = new BukkitPlayerEvents.BukkitMCPlayerJoinEvent(e);
-		//EventUtils.TriggerExternal(pje);
 		EventUtils.TriggerListener(Driver.PLAYER_JOIN, "player_join", pje);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerInteract(PlayerInteractEvent e) {
 		BukkitPlayerEvents.BukkitMCPlayerInteractEvent pie = new BukkitPlayerEvents.BukkitMCPlayerInteractEvent(e);
-		//EventUtils.TriggerExternal(pie);
 		EventUtils.TriggerListener(Driver.PLAYER_INTERACT, "player_interact", pie);
 		EventUtils.TriggerListener(Driver.PLAYER_INTERACT, "pressure_plate_activated", pie);
 	}
@@ -107,7 +99,6 @@ public class BukkitPlayerListener implements Listener {
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerRespawn(PlayerRespawnEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerRespawnEvent pre = new BukkitPlayerEvents.BukkitMCPlayerRespawnEvent(event);
-		//EventUtils.TriggerExternal(pre);
 		EventUtils.TriggerListener(Driver.PLAYER_SPAWN, "player_spawn", pre);
 	}
 
@@ -216,14 +207,12 @@ public class BukkitPlayerListener implements Listener {
 
 	private void fireChat(AsyncPlayerChatEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerChatEvent pce = new BukkitPlayerEvents.BukkitMCPlayerChatEvent(event);
-		//EventUtils.TriggerExternal(pce);
 		EventUtils.TriggerListener(Driver.PLAYER_CHAT, "player_chat", pce);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerQuit(PlayerQuitEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerQuitEvent pqe = new BukkitPlayerEvents.BukkitMCPlayerQuitEvent(event);
-		//EventUtils.TriggerExternal(pqe);
 		EventUtils.TriggerListener(Driver.PLAYER_QUIT, "player_quit", pqe);
 	}
 
@@ -233,7 +222,6 @@ public class BukkitPlayerListener implements Listener {
 		//Apparently this happens sometimes, so prevent it
 		if (!event.getFrom().equals(currentPlayer._Player().getWorld())) {
 			BukkitPlayerEvents.BukkitMCWorldChangedEvent wce = new BukkitPlayerEvents.BukkitMCWorldChangedEvent(event);
-			//EventUtils.TriggerExternal(wce);
 			EventUtils.TriggerListener(Driver.WORLD_CHANGED, "world_changed", wce);
 		}
 	}
@@ -245,7 +233,6 @@ public class BukkitPlayerListener implements Listener {
 		}
 		
 		BukkitPlayerEvents.BukkitMCPlayerTeleportEvent pte = new BukkitPlayerEvents.BukkitMCPlayerTeleportEvent(event);
-		//EventUtils.TriggerExternal(pte);
 		EventUtils.TriggerListener(Driver.PLAYER_TELEPORT, "player_teleport", pte);
 	}
 	
@@ -253,7 +240,6 @@ public class BukkitPlayerListener implements Listener {
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPortalEnter(PlayerPortalEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerPortalEvent pe = new BukkitPlayerEvents.BukkitMCPlayerPortalEvent(event);
-		//EventUtils.TriggerExternal(pe);
 		EventUtils.TriggerListener(Driver.PLAYER_PORTAL_TRAVEL, "player_portal_travel", pe);
 	}
 
@@ -261,63 +247,54 @@ public class BukkitPlayerListener implements Listener {
 	public void onConsume(PlayerItemConsumeEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerItemConsumeEvent pic = 
 				new BukkitPlayerEvents.BukkitMCPlayerItemConsumeEvent(event);
-		//EventUtils.TriggerExternal(pic);
 		EventUtils.TriggerListener(Driver.PLAYER_CONSUME, "player_consume", pic);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onFish(PlayerFishEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerFishEvent fish = new BukkitPlayerEvents.BukkitMCPlayerFishEvent(event);
-		//EventUtils.TriggerExternal(fish);
 		EventUtils.TriggerListener(Driver.PLAYER_FISH, "player_fish", fish);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onGamemodeChange(PlayerGameModeChangeEvent event) {
 		BukkitPlayerEvents.BukkitMCGamemodeChangeEvent e = new BukkitPlayerEvents.BukkitMCGamemodeChangeEvent(event);
-		//EventUtils.TriggerExternal(e);
 		EventUtils.TriggerListener(Driver.GAMEMODE_CHANGE, "gamemode_change", e);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onChatTab(PlayerChatTabCompleteEvent event) {
 		BukkitPlayerEvents.BukkitMCChatTabCompleteEvent e = new BukkitPlayerEvents.BukkitMCChatTabCompleteEvent(event);
-		//EventUtils.TriggerExternal(e);
 		EventUtils.TriggerListener(Driver.TAB_COMPLETE, "tab_complete_chat", e);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onExpChange(PlayerExpChangeEvent event) {
 		BukkitPlayerEvents.BukkitMCExpChangeEvent e = new BukkitPlayerEvents.BukkitMCExpChangeEvent(event);
-		//EventUtils.TriggerExternal(e);
 		EventUtils.TriggerListener(Driver.EXP_CHANGE, "exp_change", e);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerEditBook(PlayerEditBookEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerEditBookEvent pebe = new BukkitPlayerEvents.BukkitMCPlayerEditBookEvent(event);
-		//EventUtils.TriggerExternal(pebe);
 		EventUtils.TriggerListener(Driver.BOOK_EDITED, "book_edited", pebe);
 	}
 	
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerToggleFlight(PlayerToggleFlightEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerToggleFlightEvent ptfe = new BukkitPlayerEvents.BukkitMCPlayerToggleFlightEvent(event);
-		//EventUtils.TriggerExternal(ptfe);
 		EventUtils.TriggerListener(Driver.PLAYER_TOGGLE_FLIGHT, "player_toggle_flight", ptfe);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerToggleSneak(PlayerToggleSneakEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerToggleSneakEvent ptse = new BukkitPlayerEvents.BukkitMCPlayerToggleSneakEvent(event);
-		//EventUtils.TriggerExternal(ptse);
 		EventUtils.TriggerListener(Driver.PLAYER_TOGGLE_SNEAK, "player_toggle_sneak", ptse);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPlayerToggleSprint(PlayerToggleSprintEvent event) {
 		BukkitPlayerEvents.BukkitMCPlayerToggleSprintEvent ptse = new BukkitPlayerEvents.BukkitMCPlayerToggleSprintEvent(event);
-		//EventUtils.TriggerExternal(ptse);
 		EventUtils.TriggerListener(Driver.PLAYER_TOGGLE_SPRINT, "player_toggle_sprint", ptse);
 	}
 }

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitServerListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitServerListener.java
@@ -33,7 +33,6 @@ public class BukkitServerListener implements Listener{
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onPing(ServerListPingEvent event) {
 		BukkitMiscEvents.BukkitMCServerPingEvent pe = new BukkitMiscEvents.BukkitMCServerPingEvent(event);
-		EventUtils.TriggerExternal(pe);
 		EventUtils.TriggerListener(Driver.SERVER_PING, "server_ping", pe);
 	}
 

--- a/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitVehicleListener.java
+++ b/src/main/java/com/laytonsmith/abstraction/bukkit/events/drivers/BukkitVehicleListener.java
@@ -26,14 +26,12 @@ public class BukkitVehicleListener implements Listener{
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onEnter(VehicleEnterEvent event) {
 		BukkitMCVehicleEnterEvent vee = new BukkitMCVehicleEnterEvent(event);
-		EventUtils.TriggerExternal(vee);
 		EventUtils.TriggerListener(Driver.VEHICLE_ENTER, "vehicle_enter", vee);
 	}
 	
 	@EventHandler(priority= EventPriority.LOWEST)
 	public void onExit(VehicleExitEvent event) {
 		BukkitMCVehicleExitEvent vee = new BukkitMCVehicleExitEvent(event);
-		EventUtils.TriggerExternal(vee);
 		EventUtils.TriggerListener(Driver.VEHICLE_LEAVE, "vehicle_leave", vee);
 	}
 	
@@ -43,7 +41,6 @@ public class BukkitVehicleListener implements Listener{
 			return;
 		}
 		BukkitMCVehicleBlockCollideEvent vbc = new BukkitMCVehicleBlockCollideEvent(event);
-		EventUtils.TriggerExternal(vbc);
 		EventUtils.TriggerListener(Driver.VEHICLE_COLLIDE, "vehicle_collide", vbc);
 	}
 
@@ -51,7 +48,6 @@ public class BukkitVehicleListener implements Listener{
 	public void onEntityCollide(VehicleEntityCollisionEvent event) {
 		if (event.getVehicle().getPassenger() != event.getEntity()) {
 			BukkitMCVehicleEntityCollideEvent vec = new BukkitMCVehicleEntityCollideEvent(event);
-			EventUtils.TriggerExternal(vec);
 			EventUtils.TriggerListener(Driver.VEHICLE_COLLIDE, "vehicle_collide", vec);
 		}
 	}

--- a/src/main/java/com/laytonsmith/commandhelper/CommandHelperMessageListener.java
+++ b/src/main/java/com/laytonsmith/commandhelper/CommandHelperMessageListener.java
@@ -23,7 +23,6 @@ public class CommandHelperMessageListener implements PluginMessageListener {
 	@Override
 	public void onPluginMessageReceived(final String channel, final Player player, final byte[] bytes) {
 		BukkitMCPluginIncomingMessageEvent event = new BukkitMCPluginIncomingMessageEvent(player, channel, bytes);
-		EventUtils.TriggerExternal(event);
 		EventUtils.TriggerListener(Driver.PLUGIN_MESSAGE_RECEIVED, "plugin_message_received", event);
 	}
 }


### PR DESCRIPTION
This reduces an unbound event's operation time by about 80-90%. On my server TriggerExternal() currently adds over 0.1ms to each event.

To make the transition smoother, this commit avoids removing the functionality from events that are used by known extensions. That means player/server commands, inventory open/close, and projectile hit events still use TriggerExternal(). Some can be updated to just use TriggerListener, but as of this moment command events need TriggerExternal() to allow extensions to cancel aliases. (like with SKCompat)